### PR TITLE
Updating the report callback to point to HTTPS

### DIFF
--- a/lib/index.html
+++ b/lib/index.html
@@ -175,7 +175,7 @@
 		Press the button below to submit the scan data to the Modern.ie site and create the report.
 	</p>
 
-	<form id="reportform" action="http://www.modern.ie/report/local" method="post">
+	<form id="reportform" action="https://www.modern.ie/report/local" method="post">
 		<input type="submit" id="report" value="Create Report">
 		<input type="hidden" name="local_test_results" id="json" value="">
 	</form>


### PR DESCRIPTION
Since this is a POST, the redirect to HTTPS does not contain the data. Form action needs to point to HTTPS.

Partially solves #61.

